### PR TITLE
Fix so text size adjusts with system settings

### DIFF
--- a/Her/MainView.swift
+++ b/Her/MainView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 import UIKit
 
 struct MainView: View {
-    
     @StateObject private var callManager = CallManager()
     @FocusState private var isTextFieldFocused: Bool
     @State private var drawingHeight = true
@@ -160,12 +159,12 @@ struct OptionRow: View {
             
             VStack(alignment: .leading, spacing: 4) {
                 Text(option.title)
-                    .font(.system(size: 17, weight: .semibold))
+                    .font(.system(.headline))
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .foregroundColor(Color(uiColor: .label))
                 
                 Text(option.description)
-                    .font(.system(size: 14))
+                    .font(.system(.subheadline))
                     .foregroundColor(.gray)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
Just fixed in the obvious spot, where text size wasn't responding at all. At some point, the ui needs to be thought out a bit more though to avoid overcrowding

(context on the default typography styles  https://developer.apple.com/design/human-interface-guidelines/typography#iOS-iPadOS-Dynamic-Type-sizes)

![Screenshot 2024-03-21 at 1 32 19 AM](https://github.com/ricburton/her/assets/7482348/860320a7-b62a-4d28-81a7-e20f44d9ce14)
