### PR TITLE
Fetch jwt instead of hardcoding vapi api key

### DIFF
--- a/Her.xcodeproj/project.pbxproj
+++ b/Her.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		F3B5AB1E2BAD062D009CDBB5 /* AppSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B5AB1D2BAD062D009CDBB5 /* AppSettingsView.swift */; };
 		F3B5AB212BAD08F1009CDBB5 /* AnimationUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B5AB202BAD08F1009CDBB5 /* AnimationUtility.swift */; };
 		F3B5AB252BAE91E3009CDBB5 /* CustomLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B5AB242BAE91E3009CDBB5 /* CustomLinkView.swift */; };
+		FA5DB0392BC8B57400EB8BBB /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5DB0382BC8B57400EB8BBB /* NetworkManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -124,6 +125,7 @@
 		F3B5AB1D2BAD062D009CDBB5 /* AppSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsView.swift; sourceTree = "<group>"; };
 		F3B5AB202BAD08F1009CDBB5 /* AnimationUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationUtility.swift; sourceTree = "<group>"; };
 		F3B5AB242BAE91E3009CDBB5 /* CustomLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomLinkView.swift; sourceTree = "<group>"; };
+		FA5DB0382BC8B57400EB8BBB /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -252,6 +254,7 @@
 			isa = PBXGroup;
 			children = (
 				B95D2F322BA4EAF5003C7C17 /* CallManager.swift */,
+				FA5DB0382BC8B57400EB8BBB /* NetworkManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -450,6 +453,7 @@
 				F31C49472BC0DDC60075477D /* AudioVisualizerView.swift in Sources */,
 				1849A5472BBDD68A00A4BCF1 /* UIScreen+Extensions.swift in Sources */,
 				187277062B9B85A20079C460 /* VAPIExampleView.swift in Sources */,
+				FA5DB0392BC8B57400EB8BBB /* NetworkManager.swift in Sources */,
 				18D289E52B9713FE008742FB /* MainView.swift in Sources */,
 				F31C49412BBE75C70075477D /* VoiceSettingsView.swift in Sources */,
 				18D289E32B9713FE008742FB /* HerApp.swift in Sources */,

--- a/Her/MainView.swift
+++ b/Her/MainView.swift
@@ -54,7 +54,7 @@ struct MainView: View {
 
             // Start Button
             Button {
-                Task {  await callManager.handleCallAction() }
+                Task { await callManager.handleCallAction() }
             } label: {
                 Text(callManager.buttonText)
                     .font(.system(.title2, design: .rounded))
@@ -71,8 +71,6 @@ struct MainView: View {
             }
             .pressAnimation()
             .buttonStyle(PlainButtonStyle())
-
-            
             .disabled(callManager.callState == .loading)
             
             HStack {
@@ -98,7 +96,6 @@ struct MainView: View {
         }
         .padding()
         .padding(.horizontal, 10)
-        .onAppear { callManager.setupVapi() }
         .background {
             ZStack {
                 LinearGradient(

--- a/Her/Managers/CallManager.swift
+++ b/Her/Managers/CallManager.swift
@@ -26,13 +26,7 @@ class CallManager: ObservableObject {
     @Published var callState: CallState = .ended
     var vapiEvents = [Vapi.Event]()
     private var cancellables = Set<AnyCancellable>()
-    let vapi: Vapi
-    
-    init() {
-        vapi = Vapi(
-            publicKey: "a9a1bf8c-c389-490b-a82b-29fe9ba081d8"
-        )
-    }
+    var vapi: Vapi?
     
     @Published var enteredText = ""
     
@@ -73,6 +67,14 @@ class CallManager: ObservableObject {
     }
         
     func setupVapi() {
+        guard let vapi = self.vapi else {
+            print("Vapi is not initialized - setupVapi")
+            DispatchQueue.main.async {
+                self.callState = .ended
+            }
+            return
+        }
+        
         vapi.eventPublisher
             .sink { [weak self] event in
                 self?.vapiEvents.append(event)
@@ -124,15 +126,32 @@ class CallManager: ObservableObject {
     @MainActor
     func handleCallAction() async {
         if callState == .ended {
-            await startCall()
+            await initializeVapiAndStartCall()
         } else {
             await endCall()
         }
     }
     
     @MainActor
-    func startCall() async {
+    private func initializeVapiAndStartCall() async {
         callState = .loading
+        do {
+            let jwt = try await NetworkManager.shared.fetchJWTToken()
+            vapi = Vapi(publicKey: jwt)
+            await startCall()
+        } catch {
+            print("Failed to initialize Vapi or start call with error: \(error)")
+            callState = .ended
+        }
+    }
+
+    @MainActor
+    private func startCall() async {
+        guard let vapi = vapi else {
+            callState = .ended
+            return
+        }
+
         let assistant = [
             "model": [
                 "provider": "openai",
@@ -164,8 +183,10 @@ class CallManager: ObservableObject {
                 "provider": "deepgram"
             ]
         ] as [String : Any]
+
         do {
             try await vapi.start(assistant: assistant)
+            setupVapi()
             // Start the live activity
             let activityAttributes = Her_ExtensionAttributes(name: "Conversation")
             let initialContentState = Her_ExtensionAttributes.ContentState(sfSymbolName: "ellipsis")
@@ -200,8 +221,14 @@ class CallManager: ObservableObject {
             }
         }
     }
+
     
-    func endCall()  {
+    private func endCall() async {
+        guard let vapi = vapi else {
+            callState = .ended
+            return
+        }
+        
         vapi.stop()
         Task {
             await activity?.end(dismissalPolicy: .immediate)

--- a/Her/Managers/NetworkManager.swift
+++ b/Her/Managers/NetworkManager.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+class NetworkManager {
+    static let shared = NetworkManager()
+    private let apiBaseURL = "https://xsltilxucvfhkssumglu.supabase.co/functions/v1"
+
+    func fetchJWTToken() async throws -> String {
+        guard let url = URL(string: apiBaseURL + "/issue-vapi-token") else {
+            throw URLError(.badURL)
+        }
+
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw URLError(.badServerResponse)
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let jwt = json["jwt"] as? String else {
+            throw NSError(domain: "InvalidJWT", code: -1, userInfo: [NSLocalizedDescriptionKey: "JWT not found in response"])
+        }
+        return jwt
+    }
+}


### PR DESCRIPTION
I set up an api route to issue a temporary jwt that's signed by the vapi api key, so we don't hardcode the keys into the app. In the App, Before starting a call, it fetches a new jwt and starts the call with that.

I used Supabase for the api, since it's easy, but open to moving to something else if we need, or if anyone wants to. 

[issue-vapi-token api route](https://github.com/mikejonas/her-backend/blob/main/supabase/functions/issue-vapi-token/index.ts.)  (We should Setup a github organization for her, so that way can have an ios repo and a backend repo.)

----

I'm not used to working in swift, so if anything doesn't look right in the code, let me know. 

---

Follow up plans: 
* If we're going to open source this, as a follow up we can set it up so devs can still enter their vapi api key, instead of using  a backend route for local development.
* It would also be nice to have a swift equivalent of a .env file, for the api url or anything else like that. That way it's easy switch back and forth from localhost or prod server


