### PR TITLE
Use jwt instead of VAPI key

### DIFF
--- a/Res.xcodeproj/project.pbxproj
+++ b/Res.xcodeproj/project.pbxproj
@@ -41,6 +41,10 @@
 		F3B5AB212BAD08F1009CDBB5 /* AnimationUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B5AB202BAD08F1009CDBB5 /* AnimationUtility.swift */; };
 		F3B5AB252BAE91E3009CDBB5 /* CustomLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B5AB242BAE91E3009CDBB5 /* CustomLinkView.swift */; };
 		FA14AACB2BE80E0B001C7486 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = FA14AACA2BE80E0B001C7486 /* Config.xcconfig */; };
+		FA14AACD2BE84F43001C7486 /* SupabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA14AACC2BE84F43001C7486 /* SupabaseManager.swift */; };
+		FA14AAD02BE850A0001C7486 /* Auth in Frameworks */ = {isa = PBXBuildFile; productRef = FA14AACF2BE850A0001C7486 /* Auth */; };
+		FA14AAD22BE850A0001C7486 /* Functions in Frameworks */ = {isa = PBXBuildFile; productRef = FA14AAD12BE850A0001C7486 /* Functions */; };
+		FA14AAD42BE850A0001C7486 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = FA14AAD32BE850A0001C7486 /* Supabase */; };
 		FA7944DC2BE6D08C0035EC8B /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7944DB2BE6D08C0035EC8B /* Config.swift */; };
 /* End PBXBuildFile section */
 
@@ -120,6 +124,7 @@
 		F3B5AB202BAD08F1009CDBB5 /* AnimationUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationUtility.swift; sourceTree = "<group>"; };
 		F3B5AB242BAE91E3009CDBB5 /* CustomLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomLinkView.swift; sourceTree = "<group>"; };
 		FA14AACA2BE80E0B001C7486 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		FA14AACC2BE84F43001C7486 /* SupabaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseManager.swift; sourceTree = "<group>"; };
 		FA7944D82BE636360035EC8B /* Config.template.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.template.xcconfig; sourceTree = "<group>"; };
 		FA7944DB2BE6D08C0035EC8B /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -129,8 +134,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA14AAD42BE850A0001C7486 /* Supabase in Frameworks */,
 				18F7238D2BAC2C3C003F44FA /* Vapi in Frameworks */,
 				18F723892BAC2695003F44FA /* ActivityKit.framework in Frameworks */,
+				FA14AAD22BE850A0001C7486 /* Functions in Frameworks */,
+				FA14AAD02BE850A0001C7486 /* Auth in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -250,6 +258,7 @@
 			isa = PBXGroup;
 			children = (
 				B95D2F322BA4EAF5003C7C17 /* CallManager.swift */,
+				FA14AACC2BE84F43001C7486 /* SupabaseManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -290,6 +299,9 @@
 			name = Res;
 			packageProductDependencies = (
 				18F7238C2BAC2C3C003F44FA /* Vapi */,
+				FA14AACF2BE850A0001C7486 /* Auth */,
+				FA14AAD12BE850A0001C7486 /* Functions */,
+				FA14AAD32BE850A0001C7486 /* Supabase */,
 			);
 			productName = Her;
 			productReference = 18D289DF2B9713FE008742FB /* Res.app */;
@@ -389,6 +401,7 @@
 			packageReferences = (
 				18D28A0C2B971574008742FB /* XCRemoteSwiftPackageReference "ios" */,
 				18F07E032BD1C1A300E5B28D /* XCRemoteSwiftPackageReference "SnapKit" */,
+				FA14AACE2BE850A0001C7486 /* XCRemoteSwiftPackageReference "supabase-swift" */,
 			);
 			productRefGroup = 18D289E02B9713FE008742FB /* Products */;
 			projectDirPath = "";
@@ -450,6 +463,7 @@
 				F31C49412BBE75C70075477D /* VoiceSettingsView.swift in Sources */,
 				18D289E32B9713FE008742FB /* ResApp.swift in Sources */,
 				F3B5AB1E2BAD062D009CDBB5 /* AppSettingsView.swift in Sources */,
+				FA14AACD2BE84F43001C7486 /* SupabaseManager.swift in Sources */,
 				1849A54A2BBDD6FF00A4BCF1 /* LockScreenWidgetGuideView.swift in Sources */,
 				F3B5AB1A2BACE488009CDBB5 /* XMarkButton.swift in Sources */,
 				1849A54B2BBDD6FF00A4BCF1 /* HomeScreenWidgetGuideView.swift in Sources */,
@@ -928,6 +942,14 @@
 				minimumVersion = 5.7.1;
 			};
 		};
+		FA14AACE2BE850A0001C7486 /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/supabase/supabase-swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.5.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -940,6 +962,21 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 18D28A0C2B971574008742FB /* XCRemoteSwiftPackageReference "ios" */;
 			productName = Vapi;
+		};
+		FA14AACF2BE850A0001C7486 /* Auth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FA14AACE2BE850A0001C7486 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Auth;
+		};
+		FA14AAD12BE850A0001C7486 /* Functions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FA14AACE2BE850A0001C7486 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Functions;
+		};
+		FA14AAD32BE850A0001C7486 /* Supabase */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FA14AACE2BE850A0001C7486 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Supabase;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Res.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Res.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2298f4bfdc56429af1f6890fc1feeb79e0c8a9bc8bb57687554b0ee501f85daf",
+  "originHash" : "4f2f83c3e47ed3f9f17a1a62a60bcfc28237fdb63f4f35101f3f30a11fc7dd0c",
   "pins" : [
     {
       "identity" : "daily-client-ios",
@@ -20,12 +20,48 @@
       }
     },
     {
+      "identity" : "keychainaccess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kishikawakatsumi/KeychainAccess",
+      "state" : {
+        "revision" : "84e546727d66f1adc5439debad16270d0fdd04e7",
+        "version" : "4.2.2"
+      }
+    },
+    {
       "identity" : "snapkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SnapKit/SnapKit",
       "state" : {
         "revision" : "2842e6e84e82eb9a8dac0100ca90d9444b0307f4",
         "version" : "5.7.1"
+      }
+    },
+    {
+      "identity" : "supabase-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/supabase/supabase-swift.git",
+      "state" : {
+        "revision" : "98c9815c177f46ef85eefa9c4ce4f5e6ca0423ae",
+        "version" : "2.8.1"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "f0525da24dc3c6cbb2b6b338b65042bc91cbc4bb",
+        "version" : "3.3.0"
       }
     }
   ],

--- a/Res/Managers/SupabaseManager.swift
+++ b/Res/Managers/SupabaseManager.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Supabase
+
+class SupabaseManager {
+    static let shared = SupabaseManager()
+
+    private(set) var client: SupabaseClient
+
+    private init() {
+        self.client = SupabaseClient(
+            supabaseURL: URL(string: Config.SUPABASE_URL)!,
+            supabaseKey: Config.SUPABASE_ANON_KEY
+        )
+    }
+    
+    struct VapiTokenResponse: Decodable {
+        let jwt: String
+    }
+    func issueVapiToken() async throws -> String {
+        do {
+            let response: VapiTokenResponse = try await self.client.functions
+                .invoke(
+                    "issue-vapi-token"
+                    
+                )
+            return response.jwt
+        } catch {
+            print("Error issuing VAPI token: \(error)")
+            throw error
+        }
+    }
+}


### PR DESCRIPTION
** Before I merge this in, I'll merge in the other PR with sentry to catch errors, just to be sure it's running smoothy for everyone.

To protect the VAPI key from being exposed, we instead have an endpoint that signs a JWT with the VAPI private key. This is a security measure recommended by VAPI.

We can optimize this a bit, but for now I'm issuing a new token each time there's a call. The request only takes 50 - 100ms.

This PR also adds in the swift Supabase SDK