### PR TITLE
Add previews for all the views

### DIFF
--- a/Res.xcodeproj/project.pbxproj
+++ b/Res.xcodeproj/project.pbxproj
@@ -52,7 +52,6 @@
 		FA95764F2BEA4C3100EC2FA4 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		FA9576502BEA4C3100EC2FA4 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		FA9576522BEA4CDD00EC2FA4 /* SentryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9576512BEA4CDD00EC2FA4 /* SentryManager.swift */; };
-		FA9576572BEB4C3700EC2FA4 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		FA9576582BEB4C3700EC2FA4 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 00571768FCC847B5B370CACD /* Sentry */; };
 		FA9576972BEC099700EC2FA4 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA9576962BEC099700EC2FA4 /* XCTest.framework */; platformFilter = ios; };
 /* End PBXBuildFile section */
@@ -154,7 +153,6 @@
 				18F723892BAC2695003F44FA /* ActivityKit.framework in Frameworks */,
 				FA14AAD22BE850A0001C7486 /* Functions in Frameworks */,
 				FA14AAD02BE850A0001C7486 /* Auth in Frameworks */,
-				FA9576572BEB4C3700EC2FA4 /* (null) in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Res.xcodeproj/project.pbxproj
+++ b/Res.xcodeproj/project.pbxproj
@@ -41,17 +41,20 @@
 		F3B5AB1E2BAD062D009CDBB5 /* AppSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B5AB1D2BAD062D009CDBB5 /* AppSettingsView.swift */; };
 		F3B5AB212BAD08F1009CDBB5 /* AnimationUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B5AB202BAD08F1009CDBB5 /* AnimationUtility.swift */; };
 		F3B5AB252BAE91E3009CDBB5 /* CustomLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B5AB242BAE91E3009CDBB5 /* CustomLinkView.swift */; };
-		FA14AACB2BE80E0B001C7486 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = FA14AACA2BE80E0B001C7486 /* Config.xcconfig */; };
 		FA14AACD2BE84F43001C7486 /* SupabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA14AACC2BE84F43001C7486 /* SupabaseManager.swift */; };
 		FA14AAD02BE850A0001C7486 /* Auth in Frameworks */ = {isa = PBXBuildFile; productRef = FA14AACF2BE850A0001C7486 /* Auth */; };
 		FA14AAD22BE850A0001C7486 /* Functions in Frameworks */ = {isa = PBXBuildFile; productRef = FA14AAD12BE850A0001C7486 /* Functions */; };
 		FA14AAD42BE850A0001C7486 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = FA14AAD32BE850A0001C7486 /* Supabase */; };
 		FA7944DC2BE6D08C0035EC8B /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7944DB2BE6D08C0035EC8B /* Config.swift */; };
-		FA95764D2BEA4C3100EC2FA4 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
-		FA95764E2BEA4C3100EC2FA4 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 00571768FCC847B5B370CACD /* Sentry */; };
+		FA8DCFA12BEC19B800F54DCA /* ResUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8DCF9E2BEC195B00F54DCA /* ResUITests.swift */; };
+		FA8DCFA22BEC19B800F54DCA /* ResUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8DCF9F2BEC195B00F54DCA /* ResUITestsLaunchTests.swift */; };
+		FA8DCFA32BEC19C700F54DCA /* ResTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8DCF9C2BEC194900F54DCA /* ResTests.swift */; };
 		FA95764F2BEA4C3100EC2FA4 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		FA9576502BEA4C3100EC2FA4 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		FA9576522BEA4CDD00EC2FA4 /* SentryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9576512BEA4CDD00EC2FA4 /* SentryManager.swift */; };
+		FA9576572BEB4C3700EC2FA4 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
+		FA9576582BEB4C3700EC2FA4 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 00571768FCC847B5B370CACD /* Sentry */; };
+		FA9576972BEC099700EC2FA4 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA9576962BEC099700EC2FA4 /* XCTest.framework */; platformFilter = ios; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -133,7 +136,11 @@
 		FA14AACC2BE84F43001C7486 /* SupabaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseManager.swift; sourceTree = "<group>"; };
 		FA7944D82BE636360035EC8B /* Config.template.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.template.xcconfig; sourceTree = "<group>"; };
 		FA7944DB2BE6D08C0035EC8B /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
+		FA8DCF9C2BEC194900F54DCA /* ResTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResTests.swift; sourceTree = "<group>"; };
+		FA8DCF9E2BEC195B00F54DCA /* ResUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResUITests.swift; sourceTree = "<group>"; };
+		FA8DCF9F2BEC195B00F54DCA /* ResUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		FA9576512BEA4CDD00EC2FA4 /* SentryManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentryManager.swift; sourceTree = "<group>"; };
+		FA9576962BEC099700EC2FA4 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,12 +148,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA9576582BEB4C3700EC2FA4 /* Sentry in Frameworks */,
 				FA14AAD42BE850A0001C7486 /* Supabase in Frameworks */,
 				18F7238D2BAC2C3C003F44FA /* Vapi in Frameworks */,
 				18F723892BAC2695003F44FA /* ActivityKit.framework in Frameworks */,
 				FA14AAD22BE850A0001C7486 /* Functions in Frameworks */,
 				FA14AAD02BE850A0001C7486 /* Auth in Frameworks */,
-				2DE1830E58A749F8A3633BED /* Sentry in Frameworks */,
+				FA9576572BEB4C3700EC2FA4 /* (null) in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -155,6 +163,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FA95764F2BEA4C3100EC2FA4 /* (null) in Frameworks */,
+				FA9576972BEC099700EC2FA4 /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -184,6 +193,8 @@
 			isa = PBXGroup;
 			children = (
 				18D289E12B9713FE008742FB /* Res */,
+				FA8DCF9D2BEC194900F54DCA /* ResTests */,
+				FA8DCFA02BEC195B00F54DCA /* ResUITests */,
 				18F723312BA95060003F44FA /* Res Extension */,
 				18F7232C2BA95060003F44FA /* Frameworks */,
 				18D289E02B9713FE008742FB /* Products */,
@@ -222,6 +233,7 @@
 		18F7232C2BA95060003F44FA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				FA9576962BEC099700EC2FA4 /* XCTest.framework */,
 				18F723882BAC2694003F44FA /* ActivityKit.framework */,
 				18F7232D2BA95060003F44FA /* WidgetKit.framework */,
 				18F7232F2BA95060003F44FA /* SwiftUI.framework */,
@@ -291,6 +303,23 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		FA8DCF9D2BEC194900F54DCA /* ResTests */ = {
+			isa = PBXGroup;
+			children = (
+				FA8DCF9C2BEC194900F54DCA /* ResTests.swift */,
+			);
+			path = ResTests;
+			sourceTree = "<group>";
+		};
+		FA8DCFA02BEC195B00F54DCA /* ResUITests */ = {
+			isa = PBXGroup;
+			children = (
+				FA8DCF9E2BEC195B00F54DCA /* ResUITests.swift */,
+				FA8DCF9F2BEC195B00F54DCA /* ResUITestsLaunchTests.swift */,
+			);
+			path = ResUITests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -353,6 +382,8 @@
 				18D289FB2B9713FF008742FB /* PBXTargetDependency */,
 			);
 			name = ResUITests;
+			packageProductDependencies = (
+			);
 			productName = HerUITests;
 			productReference = 18D289F92B9713FF008742FB /* ResUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -385,7 +416,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1530;
-				LastUpgradeCheck = 1520;
+				LastUpgradeCheck = 1530;
 				TargetAttributes = {
 					18D289DE2B9713FE008742FB = {
 						CreatedOnToolsVersion = 15.2;
@@ -435,7 +466,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA14AACB2BE80E0B001C7486 /* Config.xcconfig in Resources */,
 				18D289E72B9713FF008742FB /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -518,6 +548,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA8DCFA32BEC19C700F54DCA /* ResTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -525,6 +556,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA8DCFA12BEC19B800F54DCA /* ResUITests.swift in Sources */,
+				FA8DCFA22BEC19B800F54DCA /* ResUITestsLaunchTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -772,7 +805,6 @@
 		18D28A072B9713FF008742FB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -792,7 +824,6 @@
 		18D28A082B9713FF008742FB /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -978,20 +1009,20 @@
 				minimumVersion = 5.7.1;
 			};
 		};
-		FA14AACE2BE850A0001C7486 /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/supabase/supabase-swift.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.5.1;
-			};
-		};
 		BD1914C8DBDC4BCDB400579F /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa/";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 8.0.0;
+			};
+		};
+		FA14AACE2BE850A0001C7486 /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/supabase/supabase-swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.5.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -1026,11 +1057,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = FA14AACE2BE850A0001C7486 /* XCRemoteSwiftPackageReference "supabase-swift" */;
 			productName = Supabase;
-		};
-		00571768FCC847B5B370CACD /* Sentry */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = BD1914C8DBDC4BCDB400579F /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
-			productName = Sentry;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Res.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Res.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,78 @@
+{
+  "originHash" : "db9d30212719c1fd654e323ba314ac74f7d7862124ee02e21a8a4e2e3868e173",
+  "pins" : [
+    {
+      "identity" : "daily-client-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/daily-co/daily-client-ios",
+      "state" : {
+        "revision" : "9d162add405dca91d3a9cbd721b9a592f6cad628",
+        "version" : "0.19.0"
+      }
+    },
+    {
+      "identity" : "ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/VapiAI/ios",
+      "state" : {
+        "branch" : "main",
+        "revision" : "8a07d5f8a185d5799e79f29cfd67056ac55619d9"
+      }
+    },
+    {
+      "identity" : "keychainaccess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kishikawakatsumi/KeychainAccess",
+      "state" : {
+        "revision" : "84e546727d66f1adc5439debad16270d0fdd04e7",
+        "version" : "4.2.2"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa/",
+      "state" : {
+        "revision" : "0da9c56283b8aada5ef05b16b6cbd6c2790872c4",
+        "version" : "8.25.2"
+      }
+    },
+    {
+      "identity" : "snapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SnapKit/SnapKit",
+      "state" : {
+        "revision" : "2842e6e84e82eb9a8dac0100ca90d9444b0307f4",
+        "version" : "5.7.1"
+      }
+    },
+    {
+      "identity" : "supabase-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/supabase/supabase-swift.git",
+      "state" : {
+        "revision" : "c320d2019ceb2454c53a4bc774a10c9ff702b59e",
+        "version" : "2.8.5"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "f0525da24dc3c6cbb2b6b338b65042bc91cbc4bb",
+        "version" : "3.3.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Res/Components/CustomLinkView.swift
+++ b/Res/Components/CustomLinkView.swift
@@ -86,3 +86,15 @@ struct CustomLinkView: View {
         .pressAnimation()
     }
 }
+
+#Preview("Custom Link View") {
+    CustomLinkView(
+        iconName: "link.circle",
+        title: "Navigate to Example",
+        action: {},
+        navigateTo: {},
+        screenSize: UIScreen.main.bounds.size,
+        offset: 0,
+        minHeight: 100
+    )
+}

--- a/Res/Components/CustomTextEditor.swift
+++ b/Res/Components/CustomTextEditor.swift
@@ -68,3 +68,8 @@ struct CustomTextEditor: UIViewRepresentable {
         }
     }
 }
+
+
+#Preview("Custom Text Editor") {
+    CustomTextEditor(text: .constant("Type here..."), isDisabled: false)
+}

--- a/Res/Components/HalfModalView.swift
+++ b/Res/Components/HalfModalView.swift
@@ -113,3 +113,15 @@ struct HalfModalView<Content: View>: View {
         }
     }
 }
+
+
+#Preview("Half Modal View") {
+    HalfModalView(isShown: .constant(true), onDismiss: {}, modalHeightMultiplier: -0.02) {
+        VStack {
+            Text("Modal Content Here")
+                .padding()
+                .background(Color.white)
+                .cornerRadius(10)
+        }
+    }
+}

--- a/Res/Components/Loader.swift
+++ b/Res/Components/Loader.swift
@@ -28,3 +28,8 @@ struct Loader : View {
     }
 }
     
+#Preview("Loader View") {
+    Loader()
+        .frame(width: 50, height: 50)
+        .padding()
+}

--- a/Res/Components/XMarkButton.swift
+++ b/Res/Components/XMarkButton.swift
@@ -22,3 +22,7 @@ struct XMarkButton: View {
         .pressAnimation()
     }
 }
+
+#Preview("XMark Button") {
+    XMarkButton(action: {})
+}

--- a/Res/MainView.swift
+++ b/Res/MainView.swift
@@ -385,3 +385,10 @@ extension MainView {
 #Preview {
     MainView(isAppSettingsViewShowing: .constant(false), isModalStepTwoEnabled: .constant(false))
 }
+
+#Preview("Main View - App Settings Showing") {
+    MainView(
+        isAppSettingsViewShowing: .constant(true),
+        isModalStepTwoEnabled: .constant(false)
+    )
+}

--- a/Res/Views/AppSettingsView.swift
+++ b/Res/Views/AppSettingsView.swift
@@ -20,7 +20,7 @@ struct AppSettingsView: View {
     @Binding var selectedOption: Option?
     @Binding var isModalStepTwoEnabled: Bool
     @ObservedObject var callManager: CallManager
-    @ObservedObject var keyboardResponder: KeyboardResponder  
+    @ObservedObject var keyboardResponder: KeyboardResponder
     
     var body: some View {
         ZStack {
@@ -658,3 +658,14 @@ extension AppSettingsView {
 
 }
 
+
+#Preview("App Settings View") {
+    AppSettingsView(
+        isPresented: .constant(true),
+        activeModal: .constant(nil), // Set to nil if there's no appropriate case
+        selectedOption: .constant(nil),
+        isModalStepTwoEnabled: .constant(false),
+        callManager: CallManager(),
+        keyboardResponder: KeyboardResponder()
+    )
+}

--- a/Res/Views/AudioVisualizerView.swift
+++ b/Res/Views/AudioVisualizerView.swift
@@ -39,3 +39,8 @@ struct AudioVisualizerView: View {
         }
     }
 }
+
+#Preview("Audio Visualizer View") {
+    AudioVisualizerView()
+}
+

--- a/Res/Views/CustomTextPromptView.swift
+++ b/Res/Views/CustomTextPromptView.swift
@@ -167,3 +167,14 @@ struct OptionsMenu: View {
         .padding(.horizontal, 10)
     }
 }
+
+#Preview("Custom Text Prompt View") {
+    CustomTextPromptView(
+        activeModal: .constant(nil),
+        selectedOption: .constant(nil),
+        isModalStepTwoEnabled: .constant(false),
+        callManager: CallManager(),
+        keyboardResponder: KeyboardResponder(),
+        continueAction: {}
+    )
+}

--- a/Res/Views/HomeScreenWidgetGuideView.swift
+++ b/Res/Views/HomeScreenWidgetGuideView.swift
@@ -138,3 +138,7 @@ extension HomeScreenWidgetGuideView {
         }
     }
 }
+
+#Preview {
+    HomeScreenWidgetGuideView(dismissAction: {})
+}

--- a/Res/Views/LaunchScreenViewController.swift
+++ b/Res/Views/LaunchScreenViewController.swift
@@ -62,3 +62,7 @@ class LaunchScreenViewController: UIViewController {
         }
     }
 }
+
+#Preview {
+    LaunchScreenViewController()
+}

--- a/Res/Views/LockScreenWidgetGuideView.swift
+++ b/Res/Views/LockScreenWidgetGuideView.swift
@@ -143,3 +143,6 @@ extension LockScreenWidgetGuideView {
     }
 }
 
+#Preview {
+    LockScreenWidgetGuideView(dismissAction: {})
+}

--- a/Res/Views/VoiceSettingsView.swift
+++ b/Res/Views/VoiceSettingsView.swift
@@ -116,3 +116,13 @@ struct VoiceSettingsView: View {
         )
     }
 }
+
+#Preview("Voice Settings View") {
+    VoiceSettingsView(
+        activeModal: .constant(nil),
+        selectedOption: .constant(nil),
+        isModalStepTwoEnabled: .constant(false),
+        callManager: CallManager(), // Make sure CallManager can be instantiated
+        keyboardResponder: KeyboardResponder()
+    )
+}

--- a/Res/Views/VoiceTypeAndToneSettingsView.swift
+++ b/Res/Views/VoiceTypeAndToneSettingsView.swift
@@ -148,3 +148,14 @@ extension VoiceTypeAndToneSettingsView {
                     .padding(.bottom, 20)
     }
 }
+
+#Preview("Voice Type and Tone Settings View") {
+    VoiceTypeAndToneSettingsView(
+        dismissAction: {},
+        activeModal: .constant(nil),
+        selectedOption: .constant(nil),
+        isModalStepTwoEnabled: .constant(false),
+        callManager: CallManager(),
+        keyboardResponder: KeyboardResponder()
+    )
+}

--- a/Res/Views/VoiceTypeAndToneView.swift
+++ b/Res/Views/VoiceTypeAndToneView.swift
@@ -139,3 +139,16 @@ struct VoiceTypeAndToneView: View {
         .padding(.horizontal, backgroundContext == .white ? 20 : 0)
     }
 }
+
+
+#Preview("Voice Type and Tone View") {
+    VoiceTypeAndToneView(
+        activeModal: .constant(nil),
+        selectedOption: .constant(nil),
+        callManager: CallManager(),
+        keyboardResponder: KeyboardResponder(),
+        showSaveButton: true,
+        saveSettingsAction: {},
+        backgroundContext: .white
+    )
+}

--- a/ResTests/ResTests.swift
+++ b/ResTests/ResTests.swift
@@ -1,10 +1,3 @@
-//
-//  ResTests.swift
-//  ResTests
-//
-//  Created by Mike Jonas on 5/8/24.
-//
-
 import XCTest
 
 final class ResTests: XCTestCase {

--- a/ResTests/ResTests.swift
+++ b/ResTests/ResTests.swift
@@ -1,0 +1,35 @@
+//
+//  ResTests.swift
+//  ResTests
+//
+//  Created by Mike Jonas on 5/8/24.
+//
+
+import XCTest
+
+final class ResTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/ResUITests/ResUITests.swift
+++ b/ResUITests/ResUITests.swift
@@ -1,10 +1,3 @@
-//
-//  ResUITests.swift
-//  ResUITests
-//
-//  Created by Mike Jonas on 5/8/24.
-//
-
 import XCTest
 
 final class ResUITests: XCTestCase {

--- a/ResUITests/ResUITests.swift
+++ b/ResUITests/ResUITests.swift
@@ -1,0 +1,41 @@
+//
+//  ResUITests.swift
+//  ResUITests
+//
+//  Created by Mike Jonas on 5/8/24.
+//
+
+import XCTest
+
+final class ResUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/ResUITests/ResUITestsLaunchTests.swift
+++ b/ResUITests/ResUITestsLaunchTests.swift
@@ -1,10 +1,3 @@
-//
-//  ResUITestsLaunchTests.swift
-//  ResUITests
-//
-//  Created by Mike Jonas on 5/8/24.
-//
-
 import XCTest
 
 final class ResUITestsLaunchTests: XCTestCase {

--- a/ResUITests/ResUITestsLaunchTests.swift
+++ b/ResUITests/ResUITestsLaunchTests.swift
@@ -1,0 +1,32 @@
+//
+//  ResUITestsLaunchTests.swift
+//  ResUITests
+//
+//  Created by Mike Jonas on 5/8/24.
+//
+
+import XCTest
+
+final class ResUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
Previews are useful so you can iterate on a view, without building the whole app over and over again. You can create different previews for each view, with different states.

Previews weren't working. What I found to fix it was to add ResTests and ResUITests folders and files, and then adding those to the target > (resTests / resUITests) > Build Phases > Compiled sources.

The resTests and resUITests files are the default generated files that are created with a new xcode project. Not sure if there was a reason, but ours didn't have that.

For new views, you can add a macro at the bottom like this to create a preview

```swift
#Preview {
    MainView(isAppSettingsViewShowing: .constant(false), isModalStepTwoEnabled: .constant(false))
}
```

If previews still aren't working, build the project, or file > packages > resolve package versions (or build packages), then build the project.

![Screenshot 2024-05-08 at 2 42 03 PM](https://github.com/rescomputer/res-ios/assets/7482348/c32dbc50-ca79-4474-b3b8-cab7904ff078)
![Screenshot 2024-05-08 at 2 42 26 PM](https://github.com/rescomputer/res-ios/assets/7482348/1e2f4602-34ba-456f-b7ba-69c63701367f)
![Screenshot 2024-05-08 at 2 42 37 PM](https://github.com/rescomputer/res-ios/assets/7482348/07e80fea-311a-4607-8014-9db2a02db194)
![Screenshot 2024-05-08 at 2 42 48 PM](https://github.com/rescomputer/res-ios/assets/7482348/d975f51d-bbd2-4c33-81fe-c944f3854bb2)

