### PR TITLE
Save call to db

### DIFF
--- a/Res.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Res.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "db9d30212719c1fd654e323ba314ac74f7d7862124ee02e21a8a4e2e3868e173",
   "pins" : [
     {
       "identity" : "daily-client-ios",
@@ -15,7 +16,7 @@
       "location" : "https://github.com/VapiAI/ios",
       "state" : {
         "branch" : "main",
-        "revision" : "8a07d5f8a185d5799e79f29cfd67056ac55619d9"
+        "revision" : "2867e22c962e49e342a22a6912c957bd2a050839"
       }
     },
     {
@@ -50,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/supabase/supabase-swift.git",
       "state" : {
-        "revision" : "d61365ac8fd142e2992933ed4bc2c641faae6097",
-        "version" : "2.10.0"
+        "revision" : "7222c4bb5a1f447915b43501faad7eaf89e50115",
+        "version" : "2.11.0"
       }
     },
     {
@@ -73,5 +74,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Res/Managers/CallManager.swift
+++ b/Res/Managers/CallManager.swift
@@ -196,7 +196,13 @@ class CallManager: ObservableObject {
             ]
         ] as [String : Any]
         do {
-            _ = try await vapi.start(assistant: assistant)
+            let call = try await vapi.start(assistant: assistant)
+
+            do {
+                try await SupabaseManager.shared.insertCallRecord(callUUID: call.id)
+            } catch {
+                SentryManager.shared.captureError(error, description: "Error inserting call record into db")
+            }
             
             setupVapi()
             stopPlayingSounds()
@@ -208,7 +214,7 @@ class CallManager: ObservableObject {
             activity = try Activity<Res_ExtensionAttributes>.request(attributes: activityAttributes, contentState: initialContentState)
             
         } catch {
-            SentryManager.shared.captureError(error, description: "Error starting call or requesting activity")
+            SentryManager.shared.captureError(error, description: "Error starting call")
             callState = .ended
         }
     }

--- a/Res/Managers/SupabaseManager.swift
+++ b/Res/Managers/SupabaseManager.swift
@@ -80,4 +80,26 @@ class SupabaseManager {
             throw error
         }
     }
+
+    // *****************
+    // ****** API ******
+    // *****************
+    struct CallData: Codable {
+        let id: String
+        let createdBy: String
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case createdBy = "created_by"
+        }
+    }
+
+    func insertCallRecord(callUUID: String) async throws {
+        let authedUser = try await getCurrentSession()
+        let callData = CallData(id: callUUID, createdBy: authedUser.uid)
+        try await client
+            .from("calls")
+            .insert(callData)
+            .execute()
+    }
 }


### PR DESCRIPTION
This saves the call id along with the authed in user that created the call to the database. We'll have separate logic on the backend to fetch the call details (such as cost and duration) from the vapi api after the call, and save that as well.